### PR TITLE
Prevent cmake from finding includes in miniconda.

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -2,5 +2,9 @@
 
 config()
 {
-    cmake . -DCMAKE_INSTALL_PREFIX=${PREFIX}
+# Prevent CMake from finding include files distributed in $(dirname
+# python)/../include. This is CMake's default behaviour, but can cause us to
+# erroneously use headers distributed by e.g. Anaconda.
+    PYTHONINCDIR=$(which python | sed -e's|bin/python|include|')
+    cmake . -DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_SYSTEM_IGNORE_PATH=${PYTHONINCDIR}
 }


### PR DESCRIPTION
On Ubuntu, iconv should be used from the system/compiler library but cmake finds an (inconsistent) include file in miniconda.  This change ensures that cmake will ignore all miniconda includes.